### PR TITLE
fix: Ensure consistent image display in Product-Card

### DIFF
--- a/src/components/slices/ProductCard.tsx
+++ b/src/components/slices/ProductCard.tsx
@@ -14,8 +14,8 @@ export default function ProductCard({ product, variant, addToCart }: ProductCard
   const imageUrl = getImageUrl(variant.images.thumbnail);
 
   return (
-    <div className='flex flex-col items-center rounded-lg bg-white p-4 text-center shadow-md transition-transform duration-200 ease-in-out hover:-translate-y-1'>
-      <img src={imageUrl} alt={product.name} className='h-[150px] w-full rounded-md object-cover' />
+    <div className='flex min-h-[320px] flex-col items-center rounded-lg bg-white p-4 text-center shadow-md transition-transform duration-200 ease-in-out hover:-translate-y-1'>
+      <img src={imageUrl} alt={product.name} className='h-full w-full rounded-md object-cover' />
       <h3 className='my-2 text-base font-semibold'>{product.name}</h3>
       <p className='font-bold text-black'>₩{product.price.toLocaleString()}</p>
       <Button onClick={addToCart} variant='filled-dark' shape='rounded' size='small'>


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
Please ensure you have linked the related issue.
-->

## Related Issue

<!-- Link the issue that this PR resolves. Use keywords like `Resolves` or `Closes`. -->
<!-- Example: Resolves #123 -->

- Resolves: #7 

---

## Summary of Changes

<!--
Provide a clear and concise summary of the changes.
Describe the problem and the solution.
-->

A problem has been identified where product images with different aspect ratios are being cropped or causing layout inconsistencies within the ProductCard component. 

The cause of the distortion turned out to be the set height of `img` (h-[150px]), which cropped the image while the width extended (w-full)

- [x] Changed the value of `img`'s height from `h-[150px]` to `h-full` to match the width

---

## Screenshots or GIFs

<!--
If your changes include UI modifications, please add screenshots or GIFs.
'Before' & 'After' comparisons are especially helpful for reviewers.
-->

---

## Checklist

- [x] My PR title follows the Conventional Commits format (ex: `feat: Add user login page`).
- [x] I have linked the corresponding issue.
- [x] I have removed unnecessary comments and code.
- [x] I have tested my changes and everything works as expected.

---

## Additional Comments

<!--
Is there anything specific you would like the reviewer to focus on?
Feel free to add any other context or notes about your work.
-->
