### PR TITLE
feat(responsive): Implement desktop layout for product components

### DIFF
--- a/src/components/products/FeaturedProducts.tsx
+++ b/src/components/products/FeaturedProducts.tsx
@@ -57,7 +57,7 @@ export function FeaturedProducts() {
           </button>
         ))}
       </nav>
-      <div className='mx-4 my-4 grid flex-[3] grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-4'>
+      <div className='mx-4 my-4 grid flex-[3] grid-cols-[repeat(auto-fill,minmax(240px,1fr))] gap-4'>
         {filteredProducts.map((product) => (
           <ProductCard key={product.id} product={product} />
         ))}

--- a/src/components/products/ProductCard.tsx
+++ b/src/components/products/ProductCard.tsx
@@ -36,12 +36,14 @@ export default function ProductCard({ product }: ProductCardProps) {
 
   return (
     <InternalLink to={`/products/${product.id}`}>
-      <div className='flex max-h-96 min-h-80 flex-col items-center rounded-lg bg-neutral-200 p-4 text-center text-xs shadow-md transition-opacity duration-300 ease-in-out'>
-        <img
-          src={imageUrl}
-          alt={product.name}
-          className='h-full w-full min-w-52 rounded-md object-cover'
-        />
+      <div className='flex max-h-96 min-h-80 min-w-60 flex-col items-center gap-4 rounded-lg bg-neutral-200 p-4 text-center text-xs shadow-md transition-opacity duration-300 ease-in-out'>
+        <div className='relative flex h-56 w-full grow'>
+          <img
+            src={imageUrl}
+            alt={product.name}
+            className='absolute inset-0 h-full w-full object-contain'
+          />
+        </div>
         <div className='h-16'>
           <h3 className='my-2 font-bold'>{product.name}</h3>
           <p className='font-bold text-black'>₩{product.calculatedPrice.toLocaleString()}</p>

--- a/src/components/products/ProductDetail.tsx
+++ b/src/components/products/ProductDetail.tsx
@@ -31,18 +31,19 @@ export default function ProductDetail({ product }: ProductDetailProps) {
   };
 
   return (
-    <div className='mx-5 my-4 text-center'>
-      <div className='flex min-h-80 min-w-52 flex-col items-center justify-center gap-4 rounded-lg bg-neutral-200 p-4 text-center text-xs shadow-md transition-opacity duration-300 ease-in-out'>
-        <div className='flex flex-col gap-4'>
-          <img
-            src={getImageUrl(
-              product.variants.find((v) => v.color === selectedColor)?.images.large ||
-                product.variants[0].images.large
-            )}
-            alt={product.name}
-            className='h-full max-h-96 w-full max-w-96 rounded-md object-cover'
-          />
-          <div className='my-2 flex justify-center gap-2'>
+    <div className='mx-5 my-4 flex min-h-80 min-w-60 flex-col items-center justify-center rounded-lg bg-neutral-200 p-4 text-center text-xs shadow-md transition-opacity duration-300 ease-in-out lg:flex-row lg:justify-around lg:text-sm'>
+      <img
+        src={getImageUrl(
+          product.variants.find((v) => v.color === selectedColor)?.images.large ||
+            product.variants[0].images.large
+        )}
+        alt={product.name}
+        className='h-full max-h-96 w-full max-w-96 rounded-md object-cover object-top'
+      />
+      <div className='flex flex-col lg:pr-8'>
+        <div className='flex h-32 flex-col gap-3 lg:h-48 lg:items-start lg:gap-6'>
+          <h3 className='font-bold'>{product.name}</h3>
+          <div className='flex justify-center gap-2 pb-2'>
             {product.options.colors.map((color) => (
               <button
                 key={color}
@@ -54,9 +55,6 @@ export default function ProductDetail({ product }: ProductDetailProps) {
               ></button>
             ))}
           </div>
-        </div>
-        <div className='flex h-20 flex-col gap-3'>
-          <h3 className='font-bold'>{product.name}</h3>
           <div className='flex items-center justify-center gap-2'>
             {product.options.sizes.map((size) => (
               <Button
@@ -65,7 +63,7 @@ export default function ProductDetail({ product }: ProductDetailProps) {
                 shape='rounded'
                 size='small'
                 onClick={() => setSelectedSize(size)}
-                className={`h-8 w-12 text-xs font-extrabold`}
+                className='h-7 w-10 text-xs font-extrabold'
                 variant={selectedSize === size ? 'filled-dark' : 'outlined-dark'}
               >
                 {size}


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
Please ensure you have linked the related issue.
-->

## Related Issue

<!-- Link the issue that this PR resolves. Use keywords like `Resolves` or `Closes`. -->
<!-- Example: Resolves #123 -->

- Resolves: #31 

---

## Summary of Changes

<!--
Provide a clear and concise summary of the changes.
Describe the problem and the solution.
-->

### Description

This commit introduces a desktop-optimized layout for product-related components, enhancing the user experience on larger screens. The project follows a 'Mobile-First' approach, so this work builds upon the existing mobile layout.

Previously, components like `ProductDetail` displayed in a single-column stack on all screen sizes. This update adds a multi-column layout for desktop views (`lg:` and up) to make better use of the available space.

Adjustments were also made to `ProductCard` and `FeaturedProducts` to ensure visual consistency and proper grid alignment across all breakpoints, including establishing a consistent minimum width for cards.

- **`ProductDetail.tsx`:**
  - [x] Introduced a two-column layout for desktop screens (`lg:`), displaying the image and details side-by-side.
  - [x] Maintained the existing vertical stacking layout for mobile screens.

- **`ProductCard.tsx` & `FeaturedProducts.tsx`:**
  - [x] Established a consistent minimum width for `ProductCard` to prevent layout shifts.
  - [x] Refined the responsive grid in `FeaturedProducts` to ensure consistent alignment and spacing from mobile to desktop.

---

## Screenshots or GIFs

<!--
If your changes include UI modifications, please add screenshots or GIFs.
'Before' & 'After' comparisons are especially helpful for reviewers.
-->

---

## Checklist

- [x] My PR title follows the Conventional Commits format (ex: `feat: Add user login page`).
- [x] I have linked the corresponding issue.
- [x] I have removed unnecessary comments and code.
- [x] I have tested my changes and everything works as expected.

---

## Additional Comments

<!--
Is there anything specific you would like the reviewer to focus on?
Feel free to add any other context or notes about your work.
-->
