### PR TITLE
fix: Resolve MIME type error on Vercel deployment (#33)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jay-project-c",
   "private": true,
   "version": "0.3.0",
-  "homepage": "https://jay-klmnop.github.io/Jay-Project-C",
+  "homepage": "https://jay-klmnop.github.io",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,7 +9,7 @@ import App from '@/App.tsx';
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <Provider store={store}>
-      <BrowserRouter basename='/Jay-Project-C/'>
+      <BrowserRouter>
         <App />
       </BrowserRouter>
     </Provider>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,6 @@ import path from 'path';
 
 export default defineConfig({
   plugins: [react(), svgr()],
-  base: '/Jay-Project-C/',
   resolve: {
     alias: {
       '@': path.resolve(__dirname, 'src'),


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
Please ensure you have linked the related issue.
-->

## Related Issue

<!-- Link the issue that this PR resolves. Use keywords like `Resolves` or `Closes`. -->
<!-- Example: Resolves #123 -->

- Resolves: #33 

---

## Summary of Changes

<!--
Provide a clear and concise summary of the changes.
Describe the problem and the solution.
-->

Removes the `base` configuration from `vite.config.ts`.

This configuration was intended for GitHub Pages and caused incorrect asset paths (404 errors) on Vercel. Removing it allows Vite to generate correct root-relative paths for the Vercel environment.

---

## Screenshots or GIFs

<!--
If your changes include UI modifications, please add screenshots or GIFs.
'Before' & 'After' comparisons are especially helpful for reviewers.
-->

---

## Checklist

- [x] My PR title follows the Conventional Commits format (ex: `feat: Add user login page`).
- [x] I have linked the corresponding issue.
- [x] I have removed unnecessary comments and code.
- [x] I have tested my changes and everything works as expected.

---

## Additional Comments

<!--
Is there anything specific you would like the reviewer to focus on?
Feel free to add any other context or notes about your work.
-->
