### PR TITLE
feat(theme): Implement manual theme toggle with next-themes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "clsx": "^2.1.1",
         "lodash": "^4.17.21",
         "next": "15.5.2",
+        "next-themes": "^0.4.6",
         "pretendard": "^1.3.9",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -6096,6 +6097,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "clsx": "^2.1.1",
     "lodash": "^4.17.21",
     "next": "15.5.2",
+    "next-themes": "^0.4.6",
     "pretendard": "^1.3.9",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,105 +1,106 @@
 @import 'tailwindcss';
 
-@theme {
-  --color-black: oklch(14.479% 0.00002 271.152);
-  --color-dark-gray: oklch(20.463% 0.00002 271.152);
-  --color-gray: oklch(45.678% 0.00005 271.152);
-  --color-light-gray: oklch(97.015% 0.00011 271.152);
-  --color-white: oklch(100% 0.00011 271.152);
-}
+@custom-variant dark (&.dark, .dark &);
 
 @layer base {
   body {
-    background-color: var(--color-white);
-    color: var(--color-black);
+    background-color: theme(colors.white);
+    color: theme(colors.black);
     @apply text-xs lg:text-sm;
 
     @variant dark {
-      background-color: var(--color-black);
-      color: var(--color-white);
+      background-color: theme(colors.black);
+      color: theme(colors.white);
     }
   }
 }
 
 @layer components {
   .product-card {
-    background-color: oklch(from var(--color-light-gray) l c h / 50%);
-    color: var(--color-dark-gray);
+    background-color: theme(colors.neutral.100);
+    color: theme(colors.neutral.900);
     @variant dark {
-      background-color: oklch(from var(--color-dark-gray) l c h / 50%);
-      color: var(--color-white);
+      background-color: theme(colors.neutral.900);
+      color: theme(colors.neutral.200);
     }
 
     @apply rounded-lg shadow-md;
     @apply flex flex-col items-center justify-center text-center;
   }
 
-  .filter-button {
-    @apply capitalize transition-colors;
-    color: var(--color-gray);
+  .toggle-button {
+    @apply transition-colors;
+    color: theme(colors.neutral.800);
     &[data-state='active'] {
       a&,
       & {
-        @apply font-bold;
-        color: var(--color-dark-gray);
+        color: theme(colors.black);
       }
     }
 
+    &[data-state='active'][data-open='true'] {
+      @apply font-bold;
+    }
     &:hover {
       a&,
       & {
-        color: var(--color-dark-gray);
+        color: theme(colors.neutral.900);
+        @apply cursor-pointer;
       }
     }
 
     @variant dark {
-      @apply capitalize transition-colors;
-      color: var(--color-gray);
+      @apply transition-colors;
+      color: theme(colors.neutral.300);
       &[data-state='active'] {
         a&,
         & {
-          @apply font-bold;
-          color: var(--color-white);
+          color: theme(colors.white);
         }
+      }
+
+      &[data-state='active'][data-open='true'] {
+        @apply font-bold;
       }
 
       &:hover {
         a&,
         & {
-          color: var(--color-white);
+          color: theme(colors.neutral.100);
+          @apply cursor-pointer;
         }
       }
     }
   }
 
   .header-gradation {
-    @apply bg-gradient-to-b from-neutral-700 to-transparent;
+    @apply bg-gradient-to-b from-neutral-100 to-transparent;
 
     @variant dark {
-      @apply bg-gradient-to-b from-neutral-100 to-transparent;
+      @apply bg-gradient-to-b from-neutral-700 to-transparent;
     }
   }
 
   .overlay-page {
-    background-color: oklch(from var(--color-black) l c h / 50%);
+    background-color: theme(colors.neutral.900);
   }
 
   .side-bar {
-    background-color: var(--color-white);
-    color: var(--color-black);
+    background-color: theme(colors.white);
+    color: theme(colors.black);
 
     @variant dark {
-      background-color: var(--color-black);
-      color: var(--color-white);
+      background-color: theme(colors.black);
+      color: theme(colors.white);
     }
   }
 
   .cart-product-card {
-    background-color: oklch(from var(--color-light-gray) l c h / 50%);
-    color: var(--color-dark-gray);
+    background-color: oklch(from theme(colors.neutral.100) l c h / 50%);
+    color: theme(colors.neutral.900);
     @variant dark {
-      background-color: oklch(from var(--color-dark-gray) l c h / 50%);
-      color: var(--color-white);
+      background-color: oklch(from theme(colors.neutral.900) l c h / 50%);
+      color: theme(colors.white);
     }
 
     @apply rounded-lg shadow-md;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from 'next';
 import { Pretendard } from '@/assets';
 import { CartSidebar } from '@/components/cart';
 import { Footer, Header } from '@/components/layout';
-import { RTKProvider, CartProvider } from '@/components/providers';
+import { RTKProvider, CartProvider, ThemeProvider } from '@/components/providers';
 
 export const metadata: Metadata = {
   title: 'Create Next App',
@@ -16,16 +16,18 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang='en'>
+    <html lang='en' suppressHydrationWarning>
       <body className={`${Pretendard.variable} font-sans`}>
-        <RTKProvider>
-          <CartProvider>
-            <Header />
-            <CartSidebar />
-            <main>{children}</main>
-            <Footer />
-          </CartProvider>
-        </RTKProvider>
+        <ThemeProvider defaultTheme='system' attribute='class' enableSystem>
+          <RTKProvider>
+            <CartProvider>
+              <Header />
+              <CartSidebar />
+              <main>{children}</main>
+              <Footer />
+            </CartProvider>
+          </RTKProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/components/common/ThemeToggleButton.tsx
+++ b/src/components/common/ThemeToggleButton.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { THEMES } from '@/constants';
+import { useTheme } from 'next-themes';
+import { useEffect, useState } from 'react';
+
+export function ThemeToggleButton() {
+  const { theme, setTheme, resolvedTheme } = useTheme();
+  const [isOpen, setIsOpen] = useState(false);
+
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) return null;
+
+  return (
+    <div className='flex flex-row'>
+      <button
+        onClick={() => {
+          setIsOpen((prev) => !prev);
+        }}
+        className='toggle-button'
+        data-state='active'
+        data-open={isOpen}
+      >
+        {theme === 'system' ? `system (${resolvedTheme})` : theme}
+      </button>
+      {isOpen && (
+        <div className='flex p-2'>
+          {THEMES.map((themeName) => (
+            <button
+              key={themeName}
+              onClick={() => {
+                setTheme(themeName);
+                setIsOpen(false);
+              }}
+              data-state={theme === themeName ? 'active' : 'inactive'}
+              className='toggle-button p-2 text-center'
+            >
+              {themeName}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -2,5 +2,6 @@ export { default as Button } from './Button';
 export { default as Input } from './Input';
 export { default as SearchInput } from './SearchInput';
 export { ImageWithPlaceholder } from './ImageWithPlaceholder';
+export { ThemeToggleButton } from './ThemeToggleButton';
 
 export * from './skeleton';

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { ThemeToggleButton } from '@/components/common';
 import { NavMain, NavSub, UserActions } from '@/components/layout';
 import { toggleCart, useAppDispatch } from '@/RTK';
 import Link from 'next/link';
@@ -20,6 +21,7 @@ export default function Header() {
               C:ODE
             </Link>
             <div>search</div>
+            <ThemeToggleButton />
             <NavMain className='hidden lg:flex' />
           </div>
 

--- a/src/components/layout/header/NavMain.tsx
+++ b/src/components/layout/header/NavMain.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { usePathname } from 'next/navigation';
+import { useEffect, useState } from 'react';
 import { MAIN_NAV_LINKS } from '@/constants';
 import Link from 'next/link';
 
@@ -10,15 +11,24 @@ interface NavMainProps {
 
 export default function NavMain({ className }: NavMainProps) {
   const pathname = usePathname();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return null;
+  }
 
   return (
-    <nav className={`flex flex-row items-center gap-6 ${className ?? ''}`}>
+    <nav className={`flex flex-row items-center gap-4 ${className ?? ''}`}>
       {MAIN_NAV_LINKS.map(({ href, label }) => (
         <Link
           key={label}
           href={href}
           data-state={pathname === href ? 'active' : 'inactive'}
-          className='filter-button'
+          className='toggle-button'
         >
           {label}
         </Link>

--- a/src/components/layout/header/NavSub.tsx
+++ b/src/components/layout/header/NavSub.tsx
@@ -1,8 +1,9 @@
 'use client';
 
+import { usePathname } from 'next/navigation';
+import { useEffect, useState } from 'react';
 import { SUB_NAV_ITEMS } from '@/constants';
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
 
 interface NavSubProps {
   className?: string;
@@ -10,6 +11,15 @@ interface NavSubProps {
 
 export default function NavSub({ className }: NavSubProps) {
   const pathname = usePathname();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return null;
+  }
 
   return (
     <nav className={`flex h-6 w-full flex-row items-center justify-around px-4 ${className ?? ''}`}>
@@ -18,7 +28,7 @@ export default function NavSub({ className }: NavSubProps) {
           key={href}
           href={href}
           data-state={pathname === href ? 'active' : 'inactive'}
-          className='filter-button flex h-full w-full flex-row flex-nowrap items-center justify-center gap-x-2 px-2 py-2 transition'
+          className='toggle-button flex h-full w-full flex-row flex-nowrap items-center justify-center gap-x-2 px-2 transition'
         >
           <button className='whitespace-nowrap'> {label}</button>
         </Link>

--- a/src/components/providers/ThemeProvider.tsx
+++ b/src/components/providers/ThemeProvider.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { ThemeProvider as NextThemeProvider } from 'next-themes';
+import type { ThemeProviderProps } from 'next-themes';
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return <NextThemeProvider {...props}>{children}</NextThemeProvider>;
+}

--- a/src/components/providers/index.ts
+++ b/src/components/providers/index.ts
@@ -1,2 +1,3 @@
 export { CartProvider } from './CartProvider';
 export { RTKProvider } from './RTKProvider';
+export { ThemeProvider } from './ThemeProvider';

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -3,3 +3,4 @@ export * from './footer';
 export * from './navigation';
 export * from './products';
 export * from './promotions';
+export * from './theme';

--- a/src/constants/theme.ts
+++ b/src/constants/theme.ts
@@ -1,0 +1,2 @@
+export type Theme = 'light' | 'dark' | 'system';
+export const THEMES: Theme[] = ['light', 'dark', 'system'];


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
Please ensure you have linked the related issue.
-->

## Related Issue

<!-- Link the issue that this PR resolves. Use keywords like `Resolves` or `Closes`. -->
<!-- Example: Resolves #123 -->

- Resolves: #64 

---

## Summary of Changes

<!--
Provide a clear and concise summary of the changes.
Describe the problem and the solution.
-->

This commit introduces a manual theme toggle feature, allowing users to switch between light, dark, and system themes.

The implementation leverages the `next-themes` library to handle the complexities of theme state management, `localStorage` persistence, and SSR hydration.

- [x] **ThemeProvider:** A new `ThemeProvider` from `next-themes` is wrapped around the root layout to provide global theme context.
- [x] **ThemeToggleButton:** A client component (`'use client'`) has been created to display the current theme and allow users to select a new one.
- [x] **Hydration Fix:** `suppressHydrationWarning` has been added to the `<html>` tag, and a `mounted` state check is used within client components to prevent hydration mismatch errors.
- [x] **Constants:** Theme options ('light', 'dark', 'system') are now managed centrally in `src/constants/theme.ts`.

---

## Screenshots or GIFs

<!--
If your changes include UI modifications, please add screenshots or GIFs.
'Before' & 'After' comparisons are especially helpful for reviewers.
-->

---

## Checklist

- [x] My PR title follows the Conventional Commits format (ex: `feat: Add user login page`).
- [x] I have linked the corresponding issue.
- [x] I have removed unnecessary comments and code.
- [x] I have tested my changes and everything works as expected.

---

## Additional Comments

<!--
Is there anything specific you would like the reviewer to focus on?
Feel free to add any other context or notes about your work.
-->
