### PR TITLE
fix(performance): Implement Suspense and ErrorBoundary with @suspensive/react

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@reduxjs/toolkit": "^2.8.2",
+        "@suspensive/react": "^3.10.0",
         "@tanstack/react-query": "^5.89.0",
         "@tanstack/react-query-devtools": "^5.89.0",
         "class-variance-authority": "^0.7.1",
@@ -1333,6 +1334,15 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
+    },
+    "node_modules/@suspensive/react": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@suspensive/react/-/react-3.10.0.tgz",
+      "integrity": "sha512-JPuFedOaZHBsYrQXpMbbPez05R+FylHNkNNREE43gMFsu8BtgutzA5hJH7e2Zz5PWLH4LlnX3WGDupPoM60jWA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@reduxjs/toolkit": "^2.8.2",
+    "@suspensive/react": "^3.10.0",
     "@tanstack/react-query": "^5.89.0",
     "@tanstack/react-query-devtools": "^5.89.0",
     "class-variance-authority": "^0.7.1",

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+export default function GlobalError({ error, reset }: { error: Error; reset: () => void }) {
+  return (
+    <html>
+      <body>
+        <h2>Something went wrong!</h2>
+        <div className='hidden'>Error: ${error.message}</div>
+        <button onClick={() => reset()}>Try again</button>
+      </body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,15 +1,16 @@
 import { HeroBanner, PromoBanner } from '@/components/layout';
 import { FeaturedProducts } from '@/components/products';
 import { getAllProducts } from '@/lib/data';
+import { ErrorBoundary } from '@suspensive/react';
 
 const allProducts = await getAllProducts();
 
 export default function HomePage() {
   return (
-    <div>
+    <ErrorBoundary fallback={<div className='m-4 pt-14'>Error loading products</div>}>
       <HeroBanner />
       <PromoBanner />
       <FeaturedProducts products={allProducts} />
-    </div>
+    </ErrorBoundary>
   );
 }

--- a/src/app/products/ProductsView.tsx
+++ b/src/app/products/ProductsView.tsx
@@ -1,36 +1,52 @@
-'use client';
+'use client'; // ⬅️ 이 컴포넌트가 바로 클라이언트의 시작점
 
-import { type RefObject } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { useMemo, useEffect, Suspense } from 'react';
+import { ProductGrid, useAllProductsQuery } from '@/components/products';
+import type { CategoryFilterType, SizeFilterType, SortOptionType } from '@/constants';
+import { useIntersectionObserver } from '@/hooks';
 import { GridSkeleton } from '@/components/common';
-import { FilterSidebar, ProductGrid } from '@/components/products';
-import { ProductType } from '@/types';
+import { ErrorBoundary } from '@suspensive/react';
 
-interface ProductsViewProps {
-  products: ProductType[];
-  loadMoreRef: RefObject<HTMLDivElement>;
-  isFetchingNextPage: boolean;
-}
+export function ProductsView() {
+  const searchParams = useSearchParams();
 
-export function ProductsView({ products, loadMoreRef, isFetchingNextPage }: ProductsViewProps) {
+  const filters = useMemo(() => {
+    const categories = searchParams.getAll('category') as CategoryFilterType[];
+    const sizes = searchParams.getAll('size') as SizeFilterType[];
+
+    const sort = searchParams.get('sort') as SortOptionType;
+    const query = searchParams.get('q') ?? '';
+
+    return { category: categories, size: sizes, sort, color: [] as string[], query };
+  }, [searchParams]);
+
+  const { data, error, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useAllProductsQuery(filters);
+
+  const allProducts = useMemo(() => {
+    return data?.pages.flatMap((page) => page.results) ?? [];
+  }, [data]);
+
+  const { ref: loadMoreRef, entry } = useIntersectionObserver({
+    threshold: 0.5,
+  });
+
+  useEffect(() => {
+    if (entry?.isIntersecting && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [entry, fetchNextPage, hasNextPage, isFetchingNextPage]);
+
+  if (error) throw error;
+
   return (
-    <div className='pt-14 font-semibold md:grid md:grid-cols-4 md:gap-8'>
-      <div className='md:col-span-1'>
-        <FilterSidebar />
-      </div>
-      <main className='md:col-span-3'>
-        {products.length > 0 ? (
-          <>
-            <ProductGrid products={products} />
-            <div ref={loadMoreRef} />
-            {isFetchingNextPage && <GridSkeleton />}
-          </>
-        ) : (
-          <div>
-            <h2>No results found.</h2>
-            <p>Try adjusting your search or filters.</p>
-          </div>
-        )}
-      </main>
-    </div>
+    <ErrorBoundary fallback={<div className='m-4 pt-14'>Error loading products</div>}>
+      <Suspense fallback={<GridSkeleton count={12} />}>
+        <ProductGrid products={allProducts} />
+        <div ref={loadMoreRef} />
+        {isFetchingNextPage && <GridSkeleton count={4} />}
+      </Suspense>
+    </ErrorBoundary>
   );
 }

--- a/src/app/products/[id]/page.tsx
+++ b/src/app/products/[id]/page.tsx
@@ -1,6 +1,8 @@
 import { notFound } from 'next/navigation';
 import { ProductDetailCard } from '@/components/products';
 import { getProductById } from '@/lib/data';
+import { ErrorBoundary, Suspense } from '@suspensive/react';
+import { DetailPageSkeleton } from '@/components/common';
 
 interface ProductDetailPageProps {
   params: Promise<{ id: string }>;
@@ -15,8 +17,12 @@ export default async function ProductDetailPage({ params }: ProductDetailPagePro
   }
 
   return (
-    <div className='p-20 text-center'>
-      <ProductDetailCard product={product} />
-    </div>
+    <ErrorBoundary fallback={<div className='m-4 pt-14'>Error loading products</div>}>
+      <Suspense fallback={<DetailPageSkeleton />}>
+        <div className='p-20 text-center'>
+          <ProductDetailCard product={product} />
+        </div>
+      </Suspense>
+    </ErrorBoundary>
   );
 }

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -1,54 +1,23 @@
-'use client';
-
-import { GridSkeleton } from '@/components/common';
-import { useAllProductsQuery } from '@/components/products';
-import { useIntersectionObserver } from '@/hooks';
-import { useEffect, useMemo } from 'react';
 import { ProductsView } from './ProductsView';
-import { useSearchParams } from 'next/navigation';
-import type { CategoryFilterType, SizeFilterType, SortOptionType } from '@/constants';
+import { GridSkeleton } from '@/components/common';
+import { FilterSidebar } from '@/components/products';
+import { ErrorBoundary, Suspense } from '@suspensive/react';
 
 export default function ProductsPage() {
-  const searchParams = useSearchParams();
-
-  const filters = useMemo(() => {
-    const categories = searchParams.getAll('category') as CategoryFilterType[];
-    const sizes = searchParams.getAll('size') as SizeFilterType[];
-
-    const sort = searchParams.get('sort') as SortOptionType;
-    const query = searchParams.get('q') ?? '';
-
-    return { category: categories, size: sizes, sort, color: [] as string[], query };
-  }, [searchParams]);
-
-  const { data, error, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
-    useAllProductsQuery(filters);
-
-  const allProducts = useMemo(() => {
-    return data?.pages.flatMap((page) => page.results) ?? [];
-  }, [data]);
-
-  const { ref: loadMoreRef, entry } = useIntersectionObserver({
-    threshold: 0.5,
-  });
-
-  useEffect(() => {
-    if (entry?.isIntersecting && hasNextPage && !isFetchingNextPage) {
-      fetchNextPage();
-    }
-  }, [entry, fetchNextPage, hasNextPage, isFetchingNextPage]);
-
-  if (isLoading) {
-    return <GridSkeleton count={12} />;
-  }
-
-  if (error) return <div className='pt-14'>Error: {error.message}</div>;
-
   return (
-    <ProductsView
-      products={allProducts}
-      loadMoreRef={loadMoreRef}
-      isFetchingNextPage={isFetchingNextPage}
-    />
+    <div className='pt-14 font-semibold md:grid md:grid-cols-4 md:gap-8'>
+      <div className='md:col-span-1'>
+        <ErrorBoundary fallback={<div className='m-4 pt-14'>Error loading filters</div>}>
+          <Suspense fallback={<div>loading filters...</div>}>
+            <FilterSidebar />
+          </Suspense>
+        </ErrorBoundary>
+      </div>
+      <main className='md:col-span-3'>
+        <Suspense fallback={<GridSkeleton count={12} />}>
+          <ProductsView />
+        </Suspense>
+      </main>
+    </div>
   );
 }

--- a/src/components/search/SearchModal.tsx
+++ b/src/components/search/SearchModal.tsx
@@ -2,6 +2,7 @@
 
 import { closeSearchModal, useAppDispatch, useAppSelector } from '@/RTK';
 import { SearchInput } from '@/components/search';
+import { ErrorBoundary } from '@suspensive/react';
 
 export function SearchModal() {
   const dispatch = useAppDispatch();
@@ -17,7 +18,9 @@ export function SearchModal() {
         className='side-bar fixed top-0 left-0 w-96 p-4 pt-14 lg:w-xl'
         onClick={(e) => e.stopPropagation()}
       >
-        <SearchInput />
+        <ErrorBoundary fallback={<div className='m-4'>Unexpected error, please reload</div>}>
+          <SearchInput />
+        </ErrorBoundary>
       </div>
     </div>
   );


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
Please ensure you have linked the related issue.
-->

## Related Issue

<!-- Link the issue that this PR resolves. Use keywords like `Resolves` or `Closes`. -->
<!-- Example: Resolves #123 -->

- Resolves: #69 

---

## Summary of Changes

<!--
Provide a clear and concise summary of the changes.
Describe the problem and the solution.
-->

This commit resolves a Next.js performance warning (`CSR bailout`) and improves the application's resilience by implementing proper loading and error states using the `@suspensive/react` library.

### Key Changes:

-   **Dependency:** Added `@suspensive/react` to manage Suspense and ErrorBoundary declaratively.

-   **Suspense Boundary (`products/page.tsx`):**
    -   The client-side logic was extracted into a `ProductsView` component.
    -   This component is now wrapped with `<Suspense>` from `suspensive`, using `GridSkeleton` as a fallback. This prevents the page from client-side rendering while still allowing the use of `useSearchParams`.

-   **ErrorBoundary Setup:**
    -   `ProductsView` is also wrapped with `<ErrorBoundary>` from `suspensive`.
    -   This provides a granular error fallback for data fetching failures within the product list, without crashing the entire page.
    -   A global `error.tsx` was also added to act as a final catch-all for any unhandled errors.

This new structure not only fixes the build warning but also establishes a stable pattern for handling asynchronous states throughout the application.

---

## Screenshots or GIFs

<!--
If your changes include UI modifications, please add screenshots or GIFs.
'Before' & 'After' comparisons are especially helpful for reviewers.
-->

---

## Checklist

- [x] My PR title follows the Conventional Commits format (ex: `feat: Add user login page`).
- [x] I have linked the corresponding issue.
- [x] I have removed unnecessary comments and code.
- [x] I have tested my changes and everything works as expected.

---

## Additional Comments

<!--
Is there anything specific you would like the reviewer to focus on?
Feel free to add any other context or notes about your work.
-->
